### PR TITLE
Fix a problem using Excel from the Windows Store

### DIFF
--- a/pyxll_jupyter/extipy.py
+++ b/pyxll_jupyter/extipy.py
@@ -31,10 +31,16 @@ class ExternalIPythonKernelManager(MappingKernelManager):
             setattr(kernel, port_name, 0)
 
         # Connect to kernel started by PyXLL
-        connection_dir = os.path.join(os.environ["APPDATA"], "jupyter", "runtime")
-        connection_fname = os.environ["PYXLL_IPYTHON_CONNECTION_FILE"]
-        _log.info(f'PyXLL IPython kernel = {connection_dir}/{connection_fname}')
-        kernel.load_connection_file(os.path.join(connection_dir, connection_fname))
+        connection_file = os.environ["PYXLL_IPYTHON_CONNECTION_FILE"]
+        if not os.path.abspath(connection_file):
+            connection_dir = os.path.join(os.environ["APPDATA"], "jupyter", "runtime")
+            connection_file = os.path.join(connection_dir, connection_file)
+
+        if not os.path.exists(connection_file):
+            _log.warning(f"Jupyter connection file '{connection_file}' does not exist.")
+
+        _log.info(f'PyXLL IPython kernel = {connection_file}')
+        kernel.load_connection_file(connection_file)
 
     async def start_kernel(self, **kwargs):
         """Maybe switch to the kernel started by PyXLL.

--- a/pyxll_jupyter/widget.py
+++ b/pyxll_jupyter/widget.py
@@ -6,8 +6,11 @@ from .kernel import start_kernel, launch_jupyter
 from .browser import Browser
 from .qtimports import QWidget, QVBoxLayout
 import subprocess
+import logging
 import ctypes
 import os
+
+_log = logging.getLogger(__name__)
 
 
 class JupyterQtWidget(QWidget):
@@ -49,7 +52,10 @@ class JupyterQtWidget(QWidget):
 
         # Start the kernel and open Jupyter in a new tab
         app = start_kernel()
-        self.proc, url = launch_jupyter(app.connection_file,
+        connection_file = os.path.abspath(app.abs_connection_file)
+        _log.debug(f"Kernel started with connection file '{connection_file}'")
+
+        self.proc, url = launch_jupyter(connection_file,
                                         cwd=initial_path,
                                         timeout=timeout)
 


### PR DESCRIPTION
If Excel has been installed from the Windows Store and the Jupyter
runtime folder is in AppData then use a different path for the
connection files.

This is because Windows Store apps see a different AppData folder than
non-Windows Store apps and so if the connection file is written there
then the Jupyter process can't open it.